### PR TITLE
:fire: Hotfix to include tensorflow-serving-api at appropriate index

### DIFF
--- a/2.4/s2i/bin/assemble
+++ b/2.4/s2i/bin/assemble
@@ -31,6 +31,18 @@ while base_path:
             )
             for asset in release.get("assets", []):
                 asset_name = asset.get("name")
+                branch_endpoint = "simple/tensorflow/"
+                if "tensorflow_serving_api" in asset_name:
+                    if "cpu" in release.get("tag_name"):
+                        branch_endpoint = "jemalloc/simple/tensorflow-serving-api/"
+                    # TODO: HotFix, Not the best solution as cuda version can change!
+                    elif "gpu" in release.get("tag_name"):
+                        branch_endpoint = (
+                            "cuda10.0+jemalloc/simple/tensorflow-serving-api/"
+                        )
+                release_path = os.path.join(
+                    os.getcwd(), "index", release_name, branch_endpoint
+                )
                 wheel_file_path = os.path.join(
                     release_path, asset["name"].replace("-linux_", "-manylinux1_")
                 )


### PR DESCRIPTION
PR fixes the following issue:
- `tensorflow-serving-api` was present at `<url>/<path>/simple/tensorflow/` instead of  `<url>/<path>/simple/tensorflow-serving-api`
- Tensorflow -serving-api is moved into cpu/gpu indexes, which helps the user to have a single source  instead of having each source for each package.

Note:
- Tests and Readme would be updated in new pr later.
